### PR TITLE
swapped neutron command for openstack

### DIFF
--- a/docs/01-infrastructure-os.md
+++ b/docs/01-infrastructure-os.md
@@ -52,7 +52,7 @@ Attach the network to the router:
 openstack router add subnet kubernetes kubernetes
 ```
 
-Attack the router to the external network (assuming the external network is named $OS_EXT_NET_NAME:
+Attach the router to the external network (assuming the external network is named $OS_EXT_NET_NAME:
 
 ```
 openstack router set --external-gateway $(openstack network show $OS_EXT_NET_NAME -f value -c id) kubernetes

--- a/docs/01-infrastructure-os.md
+++ b/docs/01-infrastructure-os.md
@@ -52,10 +52,10 @@ Attach the network to the router:
 openstack router add subnet kubernetes kubernetes
 ```
 
-Attack the router to the external network:
+Attack the router to the external network (assuming the external network is named $OS_EXT_NET_NAME:
 
 ```
-neutron router-gateway-set kubernetes external
+openstack router set --external-gateway $(openstack network show $OS_EXT_NET_NAME -f value -c id) kubernetes
 ```
 
 


### PR DESCRIPTION
Not sure if you're maintaining this or not.
But there was a command requiring neutron, which isn't listed as a pre-requisite.
Here's the openstack alternative.